### PR TITLE
fix: seeds.rb uses a random country with subdivisions for each skatepark

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@ require 'open-uri'
 
 # Create sample skateparks
 35.times do |i|
+  country = ISO3166::Country.all.select { |c| c.subdivisions.any? }.sample
   skatepark = Skatepark.new(
     name_en: "Sample Skatepark #{i + rand(1000)}",
     name_el: "Sample Skatepark #{i + rand(1000)}",
@@ -9,7 +10,9 @@ require 'open-uri'
     description_el: "This is a sample skatepark description for park #{i + 1}.",
     lat: 40.935657,
     lng: 24.402491,
-    status: :published
+    status: :published,
+    country_code: country.alpha2,
+    state: country.subdivisions.values.sample['code']
   )
 
   cover_image_url = 'https://picsum.photos/200/300'


### PR DESCRIPTION
fixes: #21
Used a random `Country` **with** subdivisions for each skatepark

Tested on local db:
<table><tr><td><img width="470" height="338" alt="image" src="https://github.com/user-attachments/assets/37a20344-fc16-4d41-95df-b3a21114ea1a" /></td><td><img width="479" height="324" alt="image" src="https://github.com/user-attachments/assets/a9e13794-ae52-47e6-bc02-f68d677e22d7" /></td><td><img width="794" height="626" alt="image" src="https://github.com/user-attachments/assets/b906d1fe-fdb2-4f00-959b-35bfe1520a97" /></td></tr></table>
