### PR TITLE
feat(SK8-112): Add Go Skate Day countdown to homepage

### DIFF
--- a/app/components/go_skate_day_countdown_component.html.erb
+++ b/app/components/go_skate_day_countdown_component.html.erb
@@ -1,0 +1,12 @@
+<div
+  role="region"
+  aria-label="<%= aria_label %>"
+  class="
+    mb-8 flex items-center justify-center gap-4 rounded-2xl border border-green-800/30 bg-green-950/10 px-6 py-3
+    text-center dark:border-green-700/40 dark:bg-green-950/30
+  "
+>
+  <span class="text-2xl leading-none" aria-hidden="true">🛹</span>
+
+  <p class="text-base font-semibold text-green-950 sm:text-lg dark:text-green-100"><%= message %></p>
+</div>

--- a/app/components/go_skate_day_countdown_component.html.erb
+++ b/app/components/go_skate_day_countdown_component.html.erb
@@ -1,6 +1,6 @@
 <div
   role="region"
-  aria-label="<%= aria_label %>"
+  aria-labelledby="<%= message_id %>"
   class="
     mb-8 flex items-center justify-center gap-4 rounded-2xl border border-green-800/30 bg-green-950/10 px-6 py-3
     text-center dark:border-green-700/40 dark:bg-green-950/30
@@ -8,5 +8,7 @@
 >
   <span class="text-2xl leading-none" aria-hidden="true">🛹</span>
 
-  <p class="text-base font-semibold text-green-950 sm:text-lg dark:text-green-100"><%= message %></p>
+  <p id="<%= message_id %>" class="text-base font-semibold text-green-950 sm:text-lg dark:text-green-100">
+    <%= message %>
+  </p>
 </div>

--- a/app/components/go_skate_day_countdown_component.rb
+++ b/app/components/go_skate_day_countdown_component.rb
@@ -18,12 +18,8 @@ class GoSkateDayCountdownComponent < ViewComponent::Base
     GoSkateDay.days_remaining(@date)
   end
 
-  def aria_label
-    if celebration_day?
-      t('home.go_skate_day.aria_label_today')
-    else
-      t('home.go_skate_day.aria_label_countdown', count: days_remaining)
-    end
+  def message_id
+    'go-skate-day-countdown-message'
   end
 
   def message

--- a/app/components/go_skate_day_countdown_component.rb
+++ b/app/components/go_skate_day_countdown_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class GoSkateDayCountdownComponent < ViewComponent::Base
+  def initialize(date: Time.zone.today)
+    super()
+    @date = date.to_date
+  end
+
+  def render?
+    GoSkateDay.visible?(@date)
+  end
+
+  def celebration_day?
+    GoSkateDay.celebration_day?(@date)
+  end
+
+  def days_remaining
+    GoSkateDay.days_remaining(@date)
+  end
+
+  def aria_label
+    if celebration_day?
+      t('home.go_skate_day.aria_label_today')
+    else
+      t('home.go_skate_day.aria_label_countdown', count: days_remaining)
+    end
+  end
+
+  def message
+    if celebration_day?
+      t('home.go_skate_day.today')
+    else
+      t('home.go_skate_day.countdown', count: days_remaining)
+    end
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<%= render GoSkateDayCountdownComponent.new %>
+
 <h1 class="mb-8 text-center text-lg sm:text-3xl font-bold lg:mb-8"><%= t("explore_all_skateparks") %></h1>
 
 <section class="mb-12 lg:mb-20 flex items-center justify-center gap-2">

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -28,6 +28,11 @@ el:
   home:
     logo_alt: "Λογότυπο skateparks.gr"
     theme_toggle_aria_label: "Εναλλαγή θέματος εμφάνισης"
+    go_skate_day:
+      countdown: "%{count} ημέρες μέχρι το Go Skate Day!"
+      today: "Είναι Go Skate Day!"
+      aria_label_countdown: "Αντίστροφη μέτρηση Go Skate Day: %{count} ημέρες απομένουν"
+      aria_label_today: "Είναι Go Skate Day"
   skatepark:
     name: "Όνομα"
     images: "Φωτογραφίες"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -29,10 +29,10 @@ el:
     logo_alt: "Λογότυπο skateparks.gr"
     theme_toggle_aria_label: "Εναλλαγή θέματος εμφάνισης"
     go_skate_day:
-      countdown: "%{count} ημέρες μέχρι το Go Skate Day!"
+      countdown:
+        one: "1 ημέρα μέχρι το Go Skate Day!"
+        other: "%{count} ημέρες μέχρι το Go Skate Day!"
       today: "Είναι Go Skate Day!"
-      aria_label_countdown: "Αντίστροφη μέτρηση Go Skate Day: %{count} ημέρες απομένουν"
-      aria_label_today: "Είναι Go Skate Day"
   skatepark:
     name: "Όνομα"
     images: "Φωτογραφίες"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -30,8 +30,8 @@ el:
     theme_toggle_aria_label: "Εναλλαγή θέματος εμφάνισης"
     go_skate_day:
       countdown:
-        one: "1 ημέρα μέχρι το Go Skate Day!"
-        other: "%{count} ημέρες μέχρι το Go Skate Day!"
+        one: "1 ημέρα μέχρι την Go Skate Day!"
+        other: "%{count} ημέρες μέχρι την Go Skate Day!"
       today: "Είναι Go Skate Day!"
   skatepark:
     name: "Όνομα"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -32,7 +32,7 @@ el:
       countdown:
         one: "1 ημέρα μέχρι την Go Skate Day!"
         other: "%{count} ημέρες μέχρι την Go Skate Day!"
-      today: "Είναι Go Skate Day!"
+      today: "Go Skate Day!"
   skatepark:
     name: "Όνομα"
     images: "Φωτογραφίες"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,11 @@ en:
   home:
     logo_alt: "skateparks.gr logo"
     theme_toggle_aria_label: "Toggle website theme"
+    go_skate_day:
+      countdown: "%{count} days until Go Skate Day!"
+      today: "It's Go Skate Day!"
+      aria_label_countdown: "Go Skate Day countdown: %{count} days remaining"
+      aria_label_today: "It's Go Skate Day"
   skatepark:
     name: "Name"
     images: "Images"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,10 +29,10 @@ en:
     logo_alt: "skateparks.gr logo"
     theme_toggle_aria_label: "Toggle website theme"
     go_skate_day:
-      countdown: "%{count} days until Go Skate Day!"
+      countdown:
+        one: "1 day until Go Skate Day!"
+        other: "%{count} days until Go Skate Day!"
       today: "It's Go Skate Day!"
-      aria_label_countdown: "Go Skate Day countdown: %{count} days remaining"
-      aria_label_today: "It's Go Skate Day"
   skatepark:
     name: "Name"
     images: "Images"

--- a/lib/go_skate_day.rb
+++ b/lib/go_skate_day.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class GoSkateDay
+  MONTH = 6
+  DAY = 21
+  VISIBILITY_START_MONTH = 5
+  VISIBILITY_START_DAY = 21
+
+  class << self
+    def visible?(date = Time.zone.today)
+      date = date.to_date
+      return false if date < visibility_start_for(date.year)
+      return false if date > event_date_for(date.year)
+
+      true
+    end
+
+    def celebration_day?(date = Time.zone.today)
+      date.to_date == event_date_for(date.year)
+    end
+
+    def days_remaining(date = Time.zone.today)
+      date = date.to_date
+      (event_date_for(date.year) - date).to_i
+    end
+
+    private
+
+    def event_date_for(year)
+      Date.new(year, MONTH, DAY)
+    end
+
+    def visibility_start_for(year)
+      Date.new(year, VISIBILITY_START_MONTH, VISIBILITY_START_DAY)
+    end
+  end
+end

--- a/test/components/go_skate_day_countdown_component_test.rb
+++ b/test/components/go_skate_day_countdown_component_test.rb
@@ -46,7 +46,7 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
       I18n.with_locale(:en) do
         render_inline(GoSkateDayCountdownComponent.new)
 
-        assert_selector MESSAGE_ID, text: '1 day until Go Skate Day!'
+        assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.countdown', count: 1)
       end
     end
   end
@@ -56,7 +56,7 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
       I18n.with_locale(:el) do
         render_inline(GoSkateDayCountdownComponent.new)
 
-        assert_selector MESSAGE_ID, text: '1 ημέρα μέχρι το Go Skate Day!'
+        assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.countdown', count: 1)
       end
     end
   end

--- a/test/components/go_skate_day_countdown_component_test.rb
+++ b/test/components/go_skate_day_countdown_component_test.rb
@@ -5,6 +5,8 @@ require 'test_helper'
 class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
   include ActiveSupport::Testing::TimeHelpers
 
+  MESSAGE_ID = '#go-skate-day-countdown-message'
+
   def test_does_not_render_outside_visibility_window
     travel_to Time.zone.local(2026, 5, 20, 12) do
       render_inline(GoSkateDayCountdownComponent.new)
@@ -18,8 +20,10 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
       I18n.with_locale(:en) do
         render_inline(GoSkateDayCountdownComponent.new)
 
-        assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 11)
-        assert_selector "[aria-label='#{I18n.t('home.go_skate_day.aria_label_countdown', count: 11)}']"
+        region = page.find('[role="region"]')
+
+        assert_equal 'go-skate-day-countdown-message', region['aria-labelledby']
+        assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.countdown', count: 11)
       end
     end
   end
@@ -29,8 +33,30 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
       I18n.with_locale(:el) do
         render_inline(GoSkateDayCountdownComponent.new)
 
-        assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 11)
-        assert_selector "[aria-label='#{I18n.t('home.go_skate_day.aria_label_countdown', count: 11)}']"
+        region = page.find('[role="region"]')
+
+        assert_equal 'go-skate-day-countdown-message', region['aria-labelledby']
+        assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.countdown', count: 11)
+      end
+    end
+  end
+
+  def test_renders_singular_countdown_on_june_twentieth_in_english
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      I18n.with_locale(:en) do
+        render_inline(GoSkateDayCountdownComponent.new)
+
+        assert_selector MESSAGE_ID, text: '1 day until Go Skate Day!'
+      end
+    end
+  end
+
+  def test_renders_singular_countdown_on_june_twentieth_in_greek
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      I18n.with_locale(:el) do
+        render_inline(GoSkateDayCountdownComponent.new)
+
+        assert_selector MESSAGE_ID, text: '1 ημέρα μέχρι το Go Skate Day!'
       end
     end
   end
@@ -42,8 +68,8 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
 
         region = page.find('[role="region"]')
 
-        assert_includes region.text, I18n.t('home.go_skate_day.today')
-        assert_equal I18n.t('home.go_skate_day.aria_label_today'), region['aria-label']
+        assert_equal 'go-skate-day-countdown-message', region['aria-labelledby']
+        assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.today')
       end
     end
   end
@@ -59,6 +85,6 @@ class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
   def test_accepts_injected_date
     render_inline(GoSkateDayCountdownComponent.new(date: Date.new(2026, 6, 15)))
 
-    assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 6)
+    assert_selector MESSAGE_ID, text: I18n.t('home.go_skate_day.countdown', count: 6)
   end
 end

--- a/test/components/go_skate_day_countdown_component_test.rb
+++ b/test/components/go_skate_day_countdown_component_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GoSkateDayCountdownComponentTest < ViewComponent::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  def test_does_not_render_outside_visibility_window
+    travel_to Time.zone.local(2026, 5, 20, 12) do
+      render_inline(GoSkateDayCountdownComponent.new)
+
+      assert_no_selector '[role="region"]'
+    end
+  end
+
+  def test_renders_countdown_message_in_english
+    travel_to Time.zone.local(2026, 6, 10, 12) do
+      I18n.with_locale(:en) do
+        render_inline(GoSkateDayCountdownComponent.new)
+
+        assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 11)
+        assert_selector "[aria-label='#{I18n.t('home.go_skate_day.aria_label_countdown', count: 11)}']"
+      end
+    end
+  end
+
+  def test_renders_countdown_message_in_greek
+    travel_to Time.zone.local(2026, 6, 10, 12) do
+      I18n.with_locale(:el) do
+        render_inline(GoSkateDayCountdownComponent.new)
+
+        assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 11)
+        assert_selector "[aria-label='#{I18n.t('home.go_skate_day.aria_label_countdown', count: 11)}']"
+      end
+    end
+  end
+
+  def test_renders_celebration_message_on_june_twenty_first
+    travel_to Time.zone.local(2026, 6, 21, 12) do
+      I18n.with_locale(:en) do
+        render_inline(GoSkateDayCountdownComponent.new)
+
+        region = page.find('[role="region"]')
+
+        assert_includes region.text, I18n.t('home.go_skate_day.today')
+        assert_equal I18n.t('home.go_skate_day.aria_label_today'), region['aria-label']
+      end
+    end
+  end
+
+  def test_renders_decorative_skateboard_emoji
+    travel_to Time.zone.local(2026, 6, 10, 12) do
+      render_inline(GoSkateDayCountdownComponent.new)
+
+      assert_selector 'span[aria-hidden="true"]', text: '🛹'
+    end
+  end
+
+  def test_accepts_injected_date
+    render_inline(GoSkateDayCountdownComponent.new(date: Date.new(2026, 6, 15)))
+
+    assert_selector '[role="region"]', text: I18n.t('home.go_skate_day.countdown', count: 6)
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::TimeHelpers
+
   def setup
     @published_skatepark = create(:skatepark)
     Rails.cache.clear
@@ -166,5 +168,43 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal I18n.t('privacy.title'), assigns(:title)
     assert_equal I18n.t('privacy.meta_description'), assigns(:meta_description)
+  end
+
+  def test_get_index_renders_go_skate_day_countdown_during_visibility_window
+    travel_to Time.zone.local(2026, 5, 21, 12) do
+      get root_path
+
+      assert_response :success
+      assert_includes response.body, I18n.t('home.go_skate_day.countdown', count: 31)
+    end
+  end
+
+  def test_get_index_renders_go_skate_day_celebration_on_june_twenty_first
+    travel_to Time.zone.local(2026, 6, 21, 12) do
+      get root_path
+
+      assert_response :success
+      assert_includes response.body, 'Go Skate Day!'
+      assert_includes response.body, CGI.escapeHTML(I18n.t('home.go_skate_day.today'))
+    end
+  end
+
+  def test_get_index_hides_go_skate_day_countdown_before_visibility_window
+    travel_to Time.zone.local(2026, 5, 20, 12) do
+      get root_path
+
+      assert_response :success
+      assert_not_includes response.body, I18n.t('home.go_skate_day.countdown', count: 32)
+      assert_not_includes response.body, I18n.t('home.go_skate_day.today')
+    end
+  end
+
+  def test_get_index_hides_go_skate_day_countdown_after_visibility_window
+    travel_to Time.zone.local(2026, 6, 22, 12) do
+      get root_path
+
+      assert_response :success
+      assert_not_includes response.body, I18n.t('home.go_skate_day.today')
+    end
   end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -179,6 +179,15 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_get_index_renders_singular_go_skate_day_countdown_on_june_twentieth
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      get root_path
+
+      assert_response :success
+      assert_includes response.body, I18n.t('home.go_skate_day.countdown', count: 1)
+    end
+  end
+
   def test_get_index_renders_go_skate_day_celebration_on_june_twenty_first
     travel_to Time.zone.local(2026, 6, 21, 12) do
       get root_path

--- a/test/lib/go_skate_day_test.rb
+++ b/test/lib/go_skate_day_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GoSkateDayTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  def test_visible_on_may_twenty_first
+    travel_to Time.zone.local(2026, 5, 21, 12) do
+      assert_predicate GoSkateDay, :visible?
+    end
+  end
+
+  def test_not_visible_on_may_twentieth
+    travel_to Time.zone.local(2026, 5, 20, 12) do
+      assert_not GoSkateDay.visible?
+    end
+  end
+
+  def test_visible_on_june_twentieth
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      assert_predicate GoSkateDay, :visible?
+    end
+  end
+
+  def test_visible_on_june_twenty_first
+    travel_to Time.zone.local(2026, 6, 21, 12) do
+      assert_predicate GoSkateDay, :visible?
+    end
+  end
+
+  def test_not_visible_on_june_twenty_second
+    travel_to Time.zone.local(2026, 6, 22, 12) do
+      assert_not GoSkateDay.visible?
+    end
+  end
+
+  def test_not_visible_in_january
+    travel_to Time.zone.local(2026, 1, 15, 12) do
+      assert_not GoSkateDay.visible?
+    end
+  end
+
+  def test_celebration_day_only_on_june_twenty_first
+    travel_to Time.zone.local(2026, 6, 21, 12) do
+      assert_predicate GoSkateDay, :celebration_day?
+    end
+
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      assert_not GoSkateDay.celebration_day?
+    end
+  end
+
+  def test_days_remaining_on_may_twenty_first
+    travel_to Time.zone.local(2026, 5, 21, 12) do
+      assert_equal 31, GoSkateDay.days_remaining
+    end
+  end
+
+  def test_days_remaining_on_june_twentieth
+    travel_to Time.zone.local(2026, 6, 20, 12) do
+      assert_equal 1, GoSkateDay.days_remaining
+    end
+  end
+
+  def test_days_remaining_on_june_twenty_first
+    travel_to Time.zone.local(2026, 6, 21, 12) do
+      assert_equal 0, GoSkateDay.days_remaining
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a seasonal Go Skate Day promo card above the homepage heading from May 21 through June 21 (UTC)
- Shows a days-remaining countdown until June 20, then switches to an "It's Go Skate Day!" message on June 21
- Includes en/el copy, decorative skateboard emoji, accessible region labeling, and boundary tests

## Test plan
- [x] `bin/rails test test/lib/go_skate_day_test.rb test/components/go_skate_day_countdown_component_test.rb test/controllers/home_controller_test.rb`
- [ ] Visit homepage between May 21–June 20 and confirm countdown copy (e.g. "8 days until Go Skate Day!")
- [ ] Visit homepage on June 21 and confirm celebration message
- [ ] Confirm card is hidden outside the visibility window (before May 21, after June 21)
- [ ] Check both `en` and `el` locales

Closes SK8-112