### PR TITLE
fix(seo): consolidate default-locale URLs and expand sitemap alternates (SK8-79)

### DIFF
--- a/.agent-docs/commands.md
+++ b/.agent-docs/commands.md
@@ -13,7 +13,7 @@ sh scripts.sh lint                           # Fast linter checks (parallel Rubo
 sh scripts.sh lint --full                    # Includes Zeitwerk check
 sh scripts.sh lint --fix                     # Auto-fix then re-check
 sh scripts.sh security                       # Brakeman, bundle-audit, pnpm audit (parallel)
-sh scripts.sh ci                             # Full CI parity (all checks in parallel)
+sh scripts.sh ci                             # Full CI parity (all checks in parallel) — run before push/PR
 sh scripts.sh dev up                         # Start development server
 sh scripts.sh dev rebuild --force            # Rebuild development containers
 sh scripts.sh test-server up                 # Start test server
@@ -46,6 +46,17 @@ docker compose -f docker-compose.test.yml exec skateparks-web-test bin/rails tes
 
 - After changing **controllers** that load lists or show pages, run the relevant **controller tests** and watch for N+1 regressions; use `assert_queries` in a focused test when guarding a known-hot path (see minitest guide).
 - After changing **views/components**, run **component** and **helper** tests under `test/components` and `test/helpers`.
+
+## Pre-push / PR checklist
+
+Match GitHub Actions before pushing or opening a PR:
+
+```bash
+sh scripts.sh test --fast    # or sh scripts.sh test for coverage
+sh scripts.sh ci             # Zeitwerk, RuboCop, Prettier, Herb, Brakeman, bundle-audit, pnpm audit
+```
+
+`sh scripts.sh lint` and lefthook pre-commit hooks do **not** include `pnpm audit`. The `herb-prettier` CI job runs `pnpm audit --audit-level moderate`; use `sh scripts.sh ci` or `sh scripts.sh security` locally. Pre-push hook runs Brakeman, bundle-audit, and pnpm audit.
 
 ## Development
 

--- a/.claude/skills/rails-devops/SKILL.md
+++ b/.claude/skills/rails-devops/SKILL.md
@@ -33,8 +33,10 @@ sh scripts.sh test --fast                  # All tests without coverage
 sh scripts.sh lint                         # Fast linter checks
 sh scripts.sh lint --fix                   # Auto-fix then re-check
 sh scripts.sh security                     # Brakeman, bundle-audit, pnpm audit
-sh scripts.sh ci                           # Full CI parity
+sh scripts.sh ci                           # Full CI parity — run before push/PR
 ```
+
+**Before push or opening a PR:** `sh scripts.sh test --fast` then `sh scripts.sh ci`. Lint-only checks miss `pnpm audit`, which fails the `herb-prettier` CI job when transitive JS advisories are present.
 
 ## Docker architecture
 

--- a/.cursor/rules/skateparks-ai-guidance.mdc
+++ b/.cursor/rules/skateparks-ai-guidance.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 
 - **`AGENTS.md` is canonical** for instructions and product-quality expectations (i18n, a11y, mobile, N+1 avoidance, UI consistency). This rule file applies those expectations in Cursor; read linked `.agent-docs/` and `docs/` when relevant.
 - **Workflow entry point:** Prefer `sh scripts.sh` for development server, test server, lint, and formatter workflows whenever it supports the task. Use direct `docker compose`, `bundle`, or `pnpm` commands only when `scripts.sh` does not cover the needed operation or the task requires non-interactive automation.
+- **Pre-push CI parity:** Before commit or opening a PR, run `sh scripts.sh test --fast` and `sh scripts.sh ci`. `lint` and pre-commit hooks do not run `pnpm audit`; the `herb-prettier` CI job does.
 - **Subagent prompts:** `.claude/agents/*.md` are the canonical role prompts (shared with Claude Code and OpenCode). `.cursor/agents/` contains symlinks to those files for Cursor discovery; edit `.claude/agents/`, not the symlinks.
 - **Skills:** `.claude/skills/*/SKILL.md` is the canonical skill format. `.cursor/skills/` contains symlinks for Cursor discovery; keep content consistent with `AGENTS.md` and testing docs.
 - **Cross-tool MCP:** When changing MCP integration, keep `opencode.json`, `.mcp.json`, and `.cursor/mcp.json` aligned. See [.agent-docs/ai-tooling.md](.agent-docs/ai-tooling.md) for env placeholder differences.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,9 @@ Rails 8.1 skatepark directory app (Ruby 3.3.6, PostgreSQL 17, Hotwire, Tailwind 
 ## Rules
 
 - Do not commit unless explicitly instructed
-- All code must pass linting (RuboCop, Herb, Prettier)
+- All code must pass linting (RuboCop, Herb, Prettier) and CI parity checks (`sh scripts.sh ci`) before push
 - Prefer `sh scripts.sh` for development server, test server, lint, and formatter workflows whenever it supports the task. Fall back to direct `docker compose`, `bundle`, or `pnpm` commands only when `scripts.sh` does not cover the needed operation or automation requires a non-interactive command.
+- **Before commit/push:** Run `sh scripts.sh test --fast` (or `sh scripts.sh test` for coverage) and `sh scripts.sh ci`. Do not rely on `sh scripts.sh lint` or pre-commit hooks alone — CI also runs `pnpm audit --audit-level moderate`, which is only included in `sh scripts.sh ci` and `sh scripts.sh security`.
 - **Commit messages:** Use [Conventional Commits](https://www.conventionalcommits.org/) — see [.agent-docs/conventions.md](.agent-docs/conventions.md#commit-messages). Always include a `type` prefix and colon (e.g. `feat:`, `fix:`, `chore(agents):`). Do **not** use unprefixed subjects like `Add …` or `Refactor …`.
 
 ## Product quality (i18n, a11y, performance, UI)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,9 +23,10 @@ class ApplicationController < ActionController::Base
     return if params[:locale].blank?
     return unless params[:locale].to_s == I18n.default_locale.to_s
 
-    query = request.query_parameters.except('locale')
-    target = query.present? ? "#{request.path}?#{query.to_query}" : request.path
+    destination = request.path_parameters.merge(
+      request.query_parameters.except('locale').symbolize_keys
+    )
 
-    redirect_to target, status: :moved_permanently
+    redirect_to url_for(destination), status: :moved_permanently, allow_other_host: false
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   around_action :switch_locale
+  before_action :redirect_default_locale_param, if: -> { request.get? || request.head? }
 
   def switch_locale(&)
     locale = params[:locale] || I18n.default_locale
@@ -11,6 +12,20 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
+    return {} if I18n.locale == I18n.default_locale
+
     { locale: I18n.locale }
+  end
+
+  private
+
+  def redirect_default_locale_param
+    return if params[:locale].blank?
+    return unless params[:locale].to_s == I18n.default_locale.to_s
+
+    query = request.query_parameters.except('locale')
+    target = query.present? ? "#{request.path}?#{query.to_query}" : request.path
+
+    redirect_to target, status: :moved_permanently
   end
 end

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -13,6 +13,16 @@ module LocaleHelper
     end
   end
 
+  def locale_switch_url_options(locale)
+    options = {
+      country_code: params[:country_code],
+      state: params[:state],
+      page: params[:page],
+    }
+    options[:locale] = locale unless locale == I18n.default_locale
+    options.compact
+  end
+
   private
 
   def locale_list
@@ -22,7 +32,6 @@ module LocaleHelper
   end
 
   def locale_link(locale)
-    link_to LOCALES[locale],
-            { locale: locale, country_code: params[:country_code], state: params[:state], page: params[:page] }.compact
+    link_to LOCALES[locale], locale_switch_url_options(locale)
   end
 end

--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -6,9 +6,11 @@ module SeoHelper
   end
 
   def seo_page_url(locale:)
+    url_options = { only_path: false, protocol: 'https' }
+    url_options[:locale] = locale unless locale == I18n.default_locale
+
     url_for(
-      { only_path: false, protocol: 'https', locale: locale }
-        .merge(request.query_parameters.symbolize_keys.slice(*LOCALE_ALTERNATE_PARAMS))
+      url_options.merge(request.query_parameters.symbolize_keys.slice(*LOCALE_ALTERNATE_PARAMS))
     )
   end
 

--- a/app/views/home/_locale_selector.html.erb
+++ b/app/views/home/_locale_selector.html.erb
@@ -2,12 +2,7 @@
   <ul class="flex sm:gap-4">
     <% I18n.available_locales.each do |locale| %>
       <li>
-        <% locale_url = url_for({
-            locale: locale,
-            country_code: params[:country_code],
-            state: params[:state],
-            page: params[:page],
-          }.compact) %>
+        <% locale_url = url_for(locale_switch_url_options(locale)) %>
 
         <%= render LinkComponent.new(title: LOCALES[locale], url: locale_url, current: I18n.locale == locale) %>
       </li>

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,12 +1,18 @@
+require Rails.root.join('lib/sitemap_locale_helper')
+
 # Set the host name for URL creation
-SitemapGenerator::Sitemap.default_host = 'https://www.skateparks.gr'
+SitemapGenerator::Sitemap.default_host = SitemapLocaleHelper::DEFAULT_HOST
 
 SitemapGenerator::Sitemap.create do
-  add '/about'
-  add '/contact'
-  add '/privacy'
+  extend SitemapLocaleHelper
 
-  Skatepark.published.each do |skatepark|
-    add skatepark_path(skatepark), lastmod: skatepark.updated_at
+  add_localized '/'
+  add_localized '/skateparks'
+  add_localized '/about'
+  add_localized '/contact'
+  add_localized '/privacy'
+
+  Skatepark.published.find_each do |skatepark|
+    add_localized skatepark_path(skatepark), lastmod: skatepark.updated_at
   end
 end

--- a/docs/seo-guide.md
+++ b/docs/seo-guide.md
@@ -101,7 +101,7 @@ Both methods resolve in the **current `I18n.locale`** via Mobility.
 ### URL slugs
 
 - `to_param` returns `"#{id}-#{slug}"` (e.g. `36-royal-square-skatepark-29`).
-- Slug is generated from `name_en.parameterize` — locale-neutral path; language is conveyed via `?locale=en|el`.
+- Slug is generated from `name_en.parameterize` — locale-neutral path; Greek uses `?locale=el`.
 - Stale slugs redirect to the homepage with a flash message (not a soft 404).
 - Only **published** skateparks are reachable on the public show action.
 
@@ -238,9 +238,10 @@ Rendered only on **public** pages (`public_seo_page?` returns false for `/admin/
 
 ### Locale URL model
 
-- Locale is a **query parameter** (`?locale=en` or `?locale=el`), not a path prefix.
-- `ApplicationController#default_url_options` adds `locale: I18n.locale` to all `url_for` / path helpers.
-- `x-default` hreflang points at `I18n.default_locale` (`:en`).
+- Locale is a **query parameter** (`?locale=el`) for non-default locales; the default locale (`en`) uses clean URLs without a locale param.
+- `ApplicationController#default_url_options` adds `locale: I18n.locale` only when the current locale is not the default.
+- Explicit `?locale=en` requests receive a **301 redirect** to the clean URL, consolidating duplicate English URLs for crawlers.
+- `x-default` hreflang points at the default-locale URL (no `locale` param).
 - Language switcher (`app/views/home/_locale_selector.html.erb`) and hreflang links preserve `country_code`, `state`, and `page` when present — keeping filtered index URLs consistent across locales.
 
 ---
@@ -360,28 +361,33 @@ Admin paths are blocked from crawling. Public admin pages still emit `index, fol
 
 ### Sitemap
 
-**Config:** `config/sitemap.rb`
+**Config:** `config/sitemap.rb` (with `lib/sitemap_locale_helper.rb`)
 
 ```ruby
 SitemapGenerator::Sitemap.default_host = 'https://www.skateparks.gr'
 
 SitemapGenerator::Sitemap.create do
-  add '/about'
-  add '/contact'
-  add '/privacy'
+  extend SitemapLocaleHelper
 
-  Skatepark.published.each do |skatepark|
-    add skatepark_path(skatepark), lastmod: skatepark.updated_at
+  add_localized '/'
+  add_localized '/skateparks'
+  add_localized '/about'
+  add_localized '/contact'
+  add_localized '/privacy'
+
+  Skatepark.published.find_each do |skatepark|
+    add_localized skatepark_path(skatepark), lastmod: skatepark.updated_at
   end
 end
 ```
 
+Each entry includes `xhtml:link` alternates for `en`, `el`, and `x-default`. English URLs omit the `locale` query param; Greek URLs use `?locale=el`.
+
 | Included | Not included |
 | -------- | ------------ |
-| `/about`, `/contact`, `/privacy` | Homepage (`/`) |
-| Published skatepark show pages | Skateparks index (`/skateparks`) |
-| | Locale variants (`?locale=`) |
-| | Filtered/paginated index URLs |
+| `/`, `/skateparks`, `/about`, `/contact`, `/privacy` | Filtered/paginated index URLs |
+| Published skatepark show pages (with hreflang alternates) | Admin pages |
+| | `?locale=en` variants (canonical English URLs have no locale param) |
 
 ### Sitemap generation schedule
 
@@ -483,6 +489,9 @@ SEO behavior is covered by Minitest across models, controllers, and helpers.
 | `seo_title` / `seo_description` fallbacks | `test/models/skatepark_test.rb` | Name suffix, overrides, truncation |
 | Show page meta assigns | `test/controllers/skateparks_controller_test.rb` | Default and custom EN/EL overrides |
 | Canonical + hreflang in HTML | `test/controllers/skateparks_controller_test.rb` | HTTPS canonical, all hreflang values |
+| Default-locale redirect | `test/controllers/application_controller_test.rb` | 301 from `?locale=en` to clean URL |
+| Canonical/hreflang URL helpers | `test/helpers/seo_helper_test.rb` | Default-locale omission, filter params |
+| Sitemap locale alternates | `test/lib/sitemap_locale_helper_test.rb` | `en`, `el`, `x-default` hreflang entries |
 | Twitter Cards in HTML | `test/controllers/skateparks_controller_test.rb` | Card type and title |
 | Static page assigns | `test/controllers/home_controller_test.rb` | About, contact, privacy |
 | Admin SEO form + persist | `test/controllers/admin/skateparks_controller_test.rb` | Field rendering, PATCH persistence |
@@ -496,9 +505,9 @@ Not currently tested (worth adding if SEO regressions are a concern):
 
 - Open Graph tags in rendered HTML
 - JSON-LD content in rendered HTML
-- `canonical_url` / `hreflang_link_tags` unit tests
+- `canonical_url` / `hreflang_link_tags` unit tests (partial — see `test/helpers/seo_helper_test.rb`)
 - `skatepark_schema` and `collection_page_schema` builders
-- Sitemap URL list contents
+- Sitemap XML output contents (helper covered in `test/lib/sitemap_locale_helper_test.rb`)
 - Homepage and skateparks index default metadata
 
 Run SEO-related tests:
@@ -515,12 +524,12 @@ sh scripts.sh test test/helpers/schema_helper_test.rb
 ## Known limitations and future improvements
 
 1. **Homepage and skateparks index** use only site-wide defaults — no controller-level `@title` / `@meta_description` overrides.
-2. **Sitemap** omits `/`, `/skateparks`, and per-locale URL variants.
+2. **Sitemap** omits filtered/paginated index URLs.
 3. **`contact_details`** is a minimal meta description ("Contact" / "Στοιχεία επικοινωνίας") — weak for SERP snippets.
 4. **Custom `meta_description`** overrides are not truncated or validated — long admin input can produce long SERP snippets.
 5. **`organization_schema` `sameAs`** is an empty array placeholder for future social profile URLs.
 6. **Filter query params** (`country_code`, `state`, `page`) are preserved in canonical/hreflang URLs on any page where they appear in the request — including show pages if bookmarked with index filters.
-7. **Slug is always derived from `name_en`** — URL path is locale-neutral; only `?locale=` differs between languages.
+7. **Slug is always derived from `name_en`** — URL path is locale-neutral; only `?locale=el` differs for Greek.
 
 ---
 
@@ -540,6 +549,7 @@ sh scripts.sh test test/helpers/schema_helper_test.rb
 | Admin SEO form | `app/views/admin/skateparks/_form.html.erb` |
 | Locale switcher | `app/views/home/_locale_selector.html.erb` |
 | Locale files | `config/locales/en.yml`, `config/locales/el.yml` |
+| Sitemap locale helper | `lib/sitemap_locale_helper.rb` |
 | Sitemap config | `config/sitemap.rb` |
 | Sitemap worker | `app/workers/sitemap_worker.rb` |
 | Deploy hook | `bin/release` |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -41,3 +41,5 @@ pre-push:
       run: bundle exec brakeman -q --no-pager
     bundler-audit:
       run: bundle exec bundle-audit check --update
+    pnpm-audit:
+      run: pnpm audit --audit-level moderate

--- a/lib/sitemap_locale_helper.rb
+++ b/lib/sitemap_locale_helper.rb
@@ -1,0 +1,20 @@
+module SitemapLocaleHelper
+  DEFAULT_HOST = 'https://www.skateparks.gr'.freeze
+  DEFAULT_LOCALE = :en
+  LOCALES = %i[en el].freeze
+
+  def add_localized(path, **options)
+    alternates = LOCALES.map do |locale|
+      { href: localized_url(path, locale: locale), lang: locale.to_s }
+    end
+    alternates << { href: localized_url(path, locale: DEFAULT_LOCALE), lang: 'x-default' }
+
+    add path, options.merge(alternates: alternates)
+  end
+
+  def localized_url(path, locale:)
+    return "#{DEFAULT_HOST}#{path}" if locale == DEFAULT_LOCALE
+
+    "#{DEFAULT_HOST}#{path}?locale=#{locale}"
+  end
+end

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   dompurify: '>=3.4.9'
   picomatch: ^4.0.4
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18'
   yaml: ^2.8.3
 
 importers:
@@ -195,8 +195,8 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -222,7 +222,7 @@ packages:
     resolution: {integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -231,8 +231,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.9.1:
@@ -343,8 +343,8 @@ snapshots:
       clear-module: 4.1.3
       escalade: 3.2.0
       jiti: 2.7.0
-      postcss: 8.5.16
-      postcss-import: 16.1.1(postcss@8.5.16)
+      postcss: 8.5.23
+      postcss-import: 16.1.1(postcss@8.5.23)
       tailwindcss: 4.3.1
 
   '@popperjs/core@2.11.8': {}
@@ -445,7 +445,7 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   parent-module@2.0.0:
     dependencies:
@@ -459,9 +459,9 @@ snapshots:
 
   pify@2.3.0: {}
 
-  postcss-import@16.1.1(postcss@8.5.16):
+  postcss-import@16.1.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
@@ -473,9 +473,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 overrides:
   dompurify: ">=3.4.9"
   picomatch: "^4.0.4"
-  postcss: ">=8.5.10"
+  postcss: ">=8.5.18"
   yaml: "^2.8.3"

--- a/test/components/cookie_consent_banner_component_test.rb
+++ b/test/components/cookie_consent_banner_component_test.rb
@@ -40,7 +40,7 @@ class CookieConsentBannerComponentTest < ViewComponent::TestCase
   def test_renders_learn_more_link_to_privacy_page
     render_inline(CookieConsentBannerComponent.new)
 
-    assert_selector "a[href='#{privacy_path(locale: I18n.locale)}']", text: I18n.t('cookie_consent.learn_more')
+    assert_selector "a[href='#{privacy_path}']", text: I18n.t('cookie_consent.learn_more')
   end
 
   def test_banner_is_hidden_by_default

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -28,4 +28,11 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  def test_does_not_redirect_post_requests_with_default_locale_param
+    post session_path(locale: :en), params: { email_address: 'unknown@example.com', password: 'wrong' }
+
+    assert_response :redirect
+    assert_equal 302, response.status
+  end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @skatepark = create(:skatepark)
+  end
+
+  def test_redirects_explicit_default_locale_param_to_clean_url
+    get skatepark_path(@skatepark, locale: :en)
+
+    assert_redirected_to skatepark_path(@skatepark)
+  end
+
+  def test_preserves_non_locale_query_params_when_redirecting_default_locale
+    get skateparks_path(locale: :en, country_code: 'GR', page: 2)
+
+    assert_redirected_to skateparks_path(country_code: 'GR', page: 2)
+  end
+
+  def test_does_not_redirect_non_default_locale_param
+    get skatepark_path(@skatepark, locale: :el)
+
+    assert_response :success
+  end
+
+  def test_does_not_redirect_when_locale_param_is_absent
+    get skatepark_path(@skatepark)
+
+    assert_response :success
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -54,7 +54,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_index_renders_translated_header_logo_alt_per_locale
-    get root_path(locale: 'en')
+    get root_path
 
     assert_response :success
     assert_includes response.body, I18n.t('home.logo_alt', locale: 'en')
@@ -66,7 +66,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_index_renders_translated_theme_toggle_aria_label_per_locale
-    get root_path(locale: 'en')
+    get root_path
 
     assert_response :success
     assert_includes response.body, I18n.t('home.theme_toggle_aria_label', locale: 'en')
@@ -250,7 +250,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_privacy_renders_updated_cookies_body_in_english
-    get privacy_path(locale: :en)
+    get privacy_path
 
     assert_response :success
     assert_includes response.body, I18n.t('privacy.cookies_body', locale: :en)

--- a/test/controllers/skateparks_controller_test.rb
+++ b/test/controllers/skateparks_controller_test.rb
@@ -288,18 +288,26 @@ class SkateparksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Custom meta description.', assigns(:meta_description)
   end
 
-  def test_get_show_renders_canonical_and_hreflang_tags
-    get skatepark_path(@skatepark, locale: :en)
+  def test_get_show_renders_canonical_url_without_default_locale_param
+    get skatepark_path(@skatepark)
 
     assert_response :success
-    assert_includes response.body, %(rel="canonical" href="https://www.example.com/skateparks/#{@skatepark.to_param}?locale=en")
-    assert_includes response.body, 'hreflang="en"'
-    assert_includes response.body, 'hreflang="el"'
-    assert_includes response.body, 'hreflang="x-default"'
+    assert_includes response.body, %(rel="canonical" href="https://www.example.com/skateparks/#{@skatepark.to_param}")
+  end
+
+  def test_get_show_renders_hreflang_alternate_links
+    get skatepark_path(@skatepark)
+
+    assert_response :success
+    base_url = "https://www.example.com/skateparks/#{@skatepark.to_param}"
+
+    assert_includes response.body, %(hreflang="en" href="#{base_url}")
+    assert_includes response.body, %(hreflang="el" href="#{base_url}?locale=el")
+    assert_includes response.body, %(hreflang="x-default" href="#{base_url}")
   end
 
   def test_get_show_renders_twitter_card_tags
-    get skatepark_path(@skatepark, locale: :en)
+    get skatepark_path(@skatepark)
 
     assert_response :success
     assert_includes response.body, 'name="twitter:card" content="summary_large_image"'

--- a/test/helpers/locale_helper_test.rb
+++ b/test/helpers/locale_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class LocaleHelperTest < ActionView::TestCase
+  include LocaleHelper
+
   def test_locales_constant_defines_greek_locale
     assert_equal 'Ελληνικά', LocaleHelper::LOCALES[:el]
   end
@@ -11,5 +13,17 @@ class LocaleHelperTest < ActionView::TestCase
 
   def test_locales_constant_is_frozen
     assert_predicate LocaleHelper::LOCALES, :frozen?
+  end
+
+  def test_locale_switch_url_options_omits_default_locale
+    stubs(:params).returns(ActionController::Parameters.new(country_code: 'GR', page: '2'))
+
+    assert_equal({ country_code: 'GR', page: '2' }, locale_switch_url_options(:en))
+  end
+
+  def test_locale_switch_url_options_includes_non_default_locale
+    stubs(:params).returns(ActionController::Parameters.new(country_code: 'GR'))
+
+    assert_equal({ country_code: 'GR', locale: :el }, locale_switch_url_options(:el))
   end
 end

--- a/test/helpers/seo_helper_test.rb
+++ b/test/helpers/seo_helper_test.rb
@@ -20,4 +20,27 @@ class SeoHelperTest < ActionView::TestCase
   def test_social_image_falls_back_to_logo
     assert_includes social_image, 'logo-og.png'
   end
+
+  def test_seo_page_url_omits_locale_param_for_default_locale
+    stubs(:request).returns(stub(query_parameters: {}))
+    stubs(:url_for).with({ only_path: false, protocol: 'https' }).returns('https://www.skateparks.gr/skateparks/1-test')
+
+    assert_equal 'https://www.skateparks.gr/skateparks/1-test', seo_page_url(locale: :en)
+  end
+
+  def test_seo_page_url_includes_locale_param_for_non_default_locale
+    stubs(:request).returns(stub(query_parameters: {}))
+    stubs(:url_for).with({ only_path: false, protocol: 'https', locale: :el })
+                   .returns('https://www.skateparks.gr/skateparks/1-test?locale=el')
+
+    assert_equal 'https://www.skateparks.gr/skateparks/1-test?locale=el', seo_page_url(locale: :el)
+  end
+
+  def test_seo_page_url_preserves_filter_query_params
+    stubs(:request).returns(stub(query_parameters: { 'country_code' => 'GR', 'page' => '2', 'search' => 'bowl' }))
+    stubs(:url_for).with({ only_path: false, protocol: 'https', country_code: 'GR', page: '2' })
+                   .returns('https://www.skateparks.gr/skateparks?country_code=GR&page=2')
+
+    assert_equal 'https://www.skateparks.gr/skateparks?country_code=GR&page=2', seo_page_url(locale: :en)
+  end
 end

--- a/test/lib/sitemap_locale_helper_test.rb
+++ b/test/lib/sitemap_locale_helper_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require Rails.root.join('lib/sitemap_locale_helper')
+
+class SitemapLocaleHelperTest < ActiveSupport::TestCase
+  include SitemapLocaleHelper
+
+  def test_localized_url_omits_locale_param_for_default_locale
+    assert_equal 'https://www.skateparks.gr/skateparks/1-test', localized_url('/skateparks/1-test', locale: :en)
+  end
+
+  def test_localized_url_includes_locale_param_for_non_default_locale
+    assert_equal 'https://www.skateparks.gr/skateparks/1-test?locale=el',
+                 localized_url('/skateparks/1-test', locale: :el)
+  end
+
+  def test_add_localized_builds_hreflang_alternates
+    added = []
+    define_singleton_method(:add) do |path, options|
+      added << [path, options]
+    end
+
+    add_localized '/about'
+
+    assert_equal 1, added.size
+    path, options = added.first
+
+    assert_equal '/about', path
+    assert_equal [
+      { href: 'https://www.skateparks.gr/about', lang: 'en' },
+      { href: 'https://www.skateparks.gr/about?locale=el', lang: 'el' },
+      { href: 'https://www.skateparks.gr/about', lang: 'x-default' },
+    ], options[:alternates]
+  end
+end


### PR DESCRIPTION
## Summary
- Normalize English URLs by omitting `?locale=en` from canonicals, internal links, and sitemap entries
- Add 301 redirects from explicit `?locale=en` requests to clean URLs, preserving other query params
- Expand the sitemap with `/`, `/skateparks`, static pages, and published skatepark pages, each with `en`/`el`/`x-default` hreflang alternates

Addresses Google Search Console issues for duplicate/default-locale URLs and weak crawl signals (SK8-79).

## Test plan
- [x] `sh scripts.sh test --fast` (469 tests, 0 failures)
- [x] RuboCop, Herb lint/format, Brakeman, bundle-audit (pre-commit/pre-push hooks)
- [ ] After deploy: validate fixes in Google Search Console and request re-indexing for `/`, `/skateparks`, and key skatepark pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Default-language pages now use clean URLs without an explicit locale parameter.
  - Explicit default-locale URLs redirect to the clean version while preserving other query parameters.
  - Locale switching preserves relevant filters and pagination settings.
- **SEO**
  - Canonical and hreflang links now consistently omit the default locale query parameter while providing localized alternatives and an `x-default` URL.
  - Sitemap URLs and alternates are now generated per locale.
- **Documentation**
  - Updated the SEO guide to match the new locale URL, redirect, and sitemap behavior.
- **Tests**
  - Added/updated coverage for locale redirects and locale-aware SEO/sitemap URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->